### PR TITLE
Specify node required version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "bin": {
     "stacks-cli": "bin/cli.js"
   },
+  "engines": {
+    "node": ">=7.0.0"
+  },
   "scripts": {
     "test": "mocha"
   },


### PR DESCRIPTION
Related to #1

Note that node 8.9.1 is the latest LTS, so that might be preferable instead of 7.0.0 - but I went by the comments in #1.