### PR TITLE
Added snap (snapcraft) generation file

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: stacks-cli
+version: 'commit-29baf94'
+summary: Analyze website stack from the terminal
+description: |
+  A CLI utility that analyzes the website stack of a given website.
+
+grade: stable
+confinement: strict
+
+apps:
+  stacks-cli:
+    command: bin/stacks-cli
+    plugs:
+      - network
+
+parts:
+  stacks-cli:
+    source: https://github.com/WeiChiaChang/stacks-cli.git
+    plugin: nodejs
+    node-engine: 8.9.1
+


### PR DESCRIPTION
Snaps are installation packages similar to .deb, .rpm, flatpack, etc.
Snaps are used on Ubuntu and several other Linux distributions. 

Here is the necessary file to generate a snap package for stacks-cli.
To generate the .snap installation package, install the **snapcraft** utility.
Then, run 
`snapcraft`
The output is

```
Preparing to build stacks-cli 
Building stacks-cli 
Staging stacks-cli 
Priming stacks-cli 
Snapping 'stacks-cli' -                                                                                                                                                                              
Snapped stacks-cli_commit-29baf94_amd64.snap

```
You can then install the snap file as a developer with

`snap install --devmode stacks-cli_commit-29baf94_amd64.snap`

To publish the snap of stacks-cli, run the following:
```
snapcraft login      # Create an account if you do not have one, at https://login.launchpad.net/
snapcraft register stacks-cli    # Here you become the owner of the 'stacks-cli' name as snap package.
snapcraft push stacks-cli_commit-29baf94_amd64.snap   # Upload the snap to the store.
#   It takes a few seconds to get the app autoapproved (or see https://myapps.developer.ubuntu.com/ )
snapcraft release stacks-cli 1 stable    # Releases the snap package for anyone to install
snap install stacks-cli      # Here is how anyone can then install the utility.

```