### PR TITLE
Fix breaking background-color issue

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -178,7 +178,7 @@ let run = function (obj) {
       font: 'block',           // define the font face
       align: 'left',         // define text alignment
       colors: ['cyan'],        // define all colors
-      background: 'Black',     // define the background color
+      background: 'black',     // define the background color
       letterSpacing: 1,        // define letter spacing
       lineHeight: 1,           // define the line height
       space: true,             // define if the output text should have empty lines on top and on the bottom


### PR DESCRIPTION
Fixes the following error during startup:

```
 Ouch: "Black" is not a valid background option.
       Please use a color from the supported stack:
       [ transparent | black | red | green | yellow | blue | magenta | cyan | white | blackBright | redBright | greenBright | yellowBright | blueBright | magentaBright | cyanBright | whiteBright ]
```